### PR TITLE
Remove item from favorites

### DIFF
--- a/ml-community-monolith/app/auth.py
+++ b/ml-community-monolith/app/auth.py
@@ -68,6 +68,15 @@ def get_current_active_user(current_user: User = Depends(get_current_user)):
         raise HTTPException(status_code=400, detail="Inactive user")
     return current_user
 
+def get_current_admin_user(current_user: User = Depends(get_current_active_user)):
+    """Get the current admin user."""
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not enough permissions. Admin access required."
+        )
+    return current_user
+
 def authenticate_user(db: Session, username: str, password: str):
     """Authenticate a user with username and password."""
     user = db.query(User).filter(User.username == username).first()

--- a/ml-community-monolith/app/routers.py
+++ b/ml-community-monolith/app/routers.py
@@ -12,7 +12,7 @@ from app.core.database import get_db
 from app.core.config import settings
 from app.models import User, Hero, Item, Emblem, BuildGuide, Comment, News
 from app.schemas import UserCreate, UserUpdate, HeroCreate, HeroUpdate, BuildGuideCreate, NewsCreate
-from app.auth import get_password_hash, authenticate_user, create_access_token, get_current_user, get_current_active_user
+from app.auth import get_password_hash, authenticate_user, create_access_token, get_current_user, get_current_active_user, get_current_admin_user
 
 # Create router
 router = APIRouter()


### PR DESCRIPTION
Add `get_current_admin_user` function and import it to resolve an `ImportError`.

The application failed to start due to `ImportError: cannot import name 'get_current_admin_user' from 'app.auth'`. This PR defines the missing `get_current_admin_user` function in `app/auth.py` and imports it into `app/routers.py` to allow the application to initialize correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-70e3f895-f88d-4bf5-a699-1e566a057663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-70e3f895-f88d-4bf5-a699-1e566a057663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Define `get_current_admin_user` in `app/auth.py` and import it in `app/routers.py` to provide admin-only access and fix missing import.
> 
> - **Auth**:
>   - Add `get_current_admin_user` in `app/auth.py` to enforce admin access (`is_admin` check, 403 on failure).
> - **Routers**:
>   - Import `get_current_admin_user` in `app/routers.py` for admin-protected routes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f4a246432a90ecb9ef17c1dbd59f276af9a111e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->